### PR TITLE
Improve InsertOne to return objectId

### DIFF
--- a/src/main/java/org/wso2/carbon/connector/operations/InsertOne.java
+++ b/src/main/java/org/wso2/carbon/connector/operations/InsertOne.java
@@ -40,7 +40,6 @@ public class InsertOne extends AbstractConnector {
 
     private static final String COLLECTION = "collection";
     private static final String DOCUMENT = "document";
-    private static final String INSERT_ONE_RESULT = "{\"InsertOneResult\":\"Successful\"}";
     private static final String INVALID_MONGODB_CONFIG_MESSAGE = "MongoDB connection has not been instantiated.";
     private static final String EMPTY_DOCUMENT_MESSAGE = "The document to be inserted cannot be null or empty.";
     private static final String INVALID_DOCUMENT_MESSAGE = "The document to be inserted cannot be a JSON array. Please provide a JSON object.";
@@ -73,10 +72,14 @@ public class InsertOne extends AbstractConnector {
 
             simpleMongoClient.insertOneDocument(collection, document);
 
-            if (log.isDebugEnabled()) {
-                log.debug(INSERT_ONE_RESULT);
+            Document result = new Document("InsertOneResult", "Successful");
+            result.append("acknowledged", "true");
+            Object insertedId = document.get("_id");
+            if (insertedId != null) {
+                result.append("insertedId", insertedId);
             }
-            MongoUtils.setPayload(messageContext, INSERT_ONE_RESULT);
+
+            MongoUtils.setPayload(messageContext, document.toJson());
 
         } catch (BsonInvalidOperationException e) {
             MongoUtils.handleError(messageContext, e, MongoConstants.MONGODB_CONNECTIVITY, INVALID_DOCUMENT_MESSAGE);


### PR DESCRIPTION
## Purpose
The insertOne operation of the MongoDB connector does not return the object id of the created object. Mongosh returns a response in the following [format](https://www.mongodb.com/docs/manual/reference/method/db.collection.insertOne/#db.collection.insertone----mongosh-method-):
{
  "acknowledged": true,
  "insertedId": {
    "$oid": "64e88fd3cb19f98b6e2a2451"
  }
}

## Goals
This PR improves the connector to return an object in the format below so that current usecases do not break and the object id is also returned.
{
"InsertOneResult":"Successful",
"acknowledged": true,
  "insertedId": {
    "$oid": "64e88fd3cb19f98b6e2a2451"
  }
}